### PR TITLE
implement userDataStream endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Requires Crystal >= 0.35.1
 
 * [Source Documentation](https://mwlang.github.io/binance/)
 * [Examples](https://github.com/mwlang/binance/tree/master/examples)
-* [Official Binance API Documentation](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md)
+* [Official Binance API Documentation](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md)
 
 ## TL;DR
 
@@ -111,43 +111,46 @@ puts client.time.used_weight.inspect
 ```
 
 ### PUBLIC (NONE)
-- [x] `ping` [ping](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#test-connectivity) Test connectivity to the Rest API.
-- [x] `time` [time](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#check-server-time) Test connectivity to the Rest API and get the current server time.
-- [x] `exchange_info` [exchangeInfo](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#exchange-information) Current exchange trading rules and symbol information
-- [x] `depth` [depth (order book)](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#order-book) Get Order book depth info.
-- [x] `trades` [trades](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#recent-trades-list) Get recent trades (up to last 500).
-- [x] `agg_trades` [aggTrades](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#compressedaggregate-trades-list) Get compressed, aggregate trades.
-- [x] `klines` [klines](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#klinecandlestick-data) Kline/candlestick bars for a symbol. Klines are uniquely identified by their open time.
-- [x] `avg_price` [avgPrice](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#current-average-price) Current average price for a symbol.
-- [x] `twenty_four_hour` [ticker/24hr](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#24hr-ticker-price-change-statistics) 24 hour rolling window price change statistics.
-- [x] `price` [ticker/price](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#symbol-price-ticker) Latest price for a symbol or symbols.
-- [x] `book_ticker` [ticker/bookTicker](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#symbol-order-book-ticker) Best price/qty on the order book for a symbol or symbols.
+- [x] `ping` [ping](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#test-connectivity) Test connectivity to the Rest API.
+- [x] `time` [time](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#check-server-time) Test connectivity to the Rest API and get the current server time.
+- [x] `exchange_info` [exchangeInfo](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#exchange-information) Current exchange trading rules and symbol information
+- [x] `depth` [depth (order book)](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#order-book) Get Order book depth info.
+- [x] `trades` [trades](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#recent-trades-list) Get recent trades (up to last 500).
+- [x] `agg_trades` [aggTrades](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#compressedaggregate-trades-list) Get compressed, aggregate trades.
+- [x] `klines` [klines](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#klinecandlestick-data) Kline/candlestick bars for a symbol. Klines are uniquely identified by their open time.
+- [x] `avg_price` [avgPrice](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#current-average-price) Current average price for a symbol.
+- [x] `twenty_four_hour` [ticker/24hr](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#24hr-ticker-price-change-statistics) 24 hour rolling window price change statistics.
+- [x] `price` [ticker/price](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#symbol-price-ticker) Latest price for a symbol or symbols.
+- [x] `book_ticker` [ticker/bookTicker](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#symbol-order-book-ticker) Best price/qty on the order book for a symbol or symbols.
 
 ### MARKET_DATA (API_KEY required)
-- [x] `historical_trades` [historicalTrades](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#old-trade-lookup-market_data) Get older trades.
+- [x] `historical_trades` [historicalTrades](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#old-trade-lookup-market_data) Get older trades.
+
+### USER_DATA_STREAM (API_KEY required)
+- [x] `user_data_stream` [userDataStream](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#start-user-data-stream-user_stream) Start a new user data stream.
 
 ### SIGNED (API_KEY and signed with SECRET_KEY required)
-- [x] `account` [account](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-information-user_data) Get current account information.
-- [x] `get_order` [GET order (query)](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#query-order-user_data) Check an order's status.
-- [x] `open_orders` [GET openOrders](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#current-open-orders-user_data) Get all open orders on a symbol.
-- [x] `all_orders` [GET allOrders](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#all-orders-user_data) Get all account orders; active, canceled, or filled.
-- [x] `new_order` [POST order (new order)](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#new-order--trade) Send in a new order.
-- [x] `new_test_order` [POST order/test (test new order)](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#test-new-order-trade) Creates and validates a new order but does not send it into the matching engine.
-- [x] `cancel_order` [DELETE order (cancel order)](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#cancel-order-trade) Cancel an active order.
-- [x] `my_trades` [myTrades](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#account-trade-list-user_data) Get trades for a specific account and symbol.
+- [x] `account` [account](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#account-information-user_data) Get current account information.
+- [x] `get_order` [GET order (query)](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#query-order-user_data) Check an order's status.
+- [x] `open_orders` [GET openOrders](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#current-open-orders-user_data) Get all open orders on a symbol.
+- [x] `all_orders` [GET allOrders](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#all-orders-user_data) Get all account orders; active, canceled, or filled.
+- [x] `new_order` [POST order (new order)](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#new-order--trade) Send in a new order.
+- [x] `new_test_order` [POST order/test (test new order)](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#test-new-order-trade) Creates and validates a new order but does not send it into the matching engine.
+- [x] `cancel_order` [DELETE order (cancel order)](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#cancel-order-trade) Cancel an active order.
+- [x] `my_trades` [myTrades](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#account-trade-list-user_data) Get trades for a specific account and symbol.
 
 ## Websocket Streams
-- [x] [Aggregate Trade Streams](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#aggregate-trade-streams)
-- [x] [Trade Streams](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#trade-streams)
-- [x] [Kline/Candlestick Streams](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#klinecandlestick-streams)
-- [x] [Individual Symbol Mini Ticker Stream](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#individual-symbol-mini-ticker-stream)
-- [ ] [All Market Mini Tickers Stream](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#all-market-mini-tickers-stream)
-- [x] [Individual Symbol Ticker Streams](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#individual-symbol-ticker-streams)
-- [ ] [All Market Tickers Stream](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#all-market-tickers-stream)
-- [x] [Individual Symbol Book Ticker Streams](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#individual-symbol-book-ticker-streams)
-- [ ] [All Book Tickers Stream](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#all-book-tickers-stream)
-- [x] [Partial Book Depth Streams](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#partial-book-depth-streams)
-- [x] [Diff Depth Stream](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#diff-depth-stream)
+- [x] [Aggregate Trade Streams](https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#aggregate-trade-streams)
+- [x] [Trade Streams](https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#trade-streams)
+- [x] [Kline/Candlestick Streams](https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#klinecandlestick-streams)
+- [x] [Individual Symbol Mini Ticker Stream](https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#individual-symbol-mini-ticker-stream)
+- [ ] [All Market Mini Tickers Stream](https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#all-market-mini-tickers-stream)
+- [x] [Individual Symbol Ticker Streams](https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#individual-symbol-ticker-streams)
+- [ ] [All Market Tickers Stream](https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#all-market-tickers-stream)
+- [x] [Individual Symbol Book Ticker Streams](https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#individual-symbol-book-ticker-streams)
+- [ ] [All Book Tickers Stream](https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#all-book-tickers-stream)
+- [x] [Partial Book Depth Streams](https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#partial-book-depth-streams)
+- [x] [Diff Depth Stream](https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#diff-depth-stream)
 
 ## Installation
 
@@ -455,7 +458,7 @@ QTUMETH bid: 0.017040 ask: 0.017126 change: -0.719 high: 0.017617 low: 0.016782
 
 NOTE: used_weight is cumulative
 Each endpoint has it's own Response object derived from the ServerResponse object and, consequentially, the specific properties that are mapped to the JSON.  For example,
-the [time](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#check-server-time) endpoint returns a `TimeResponse` with one additional property value, the "serverTime", accessible as follows:
+the [time](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#check-server-time) endpoint returns a `TimeResponse` with one additional property value, the "serverTime", accessible as follows:
 
 ```crystal
 require "binance"

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: binance
-version: 0.7.2
+version: 0.7.3
 
 authors:
   - mwlang <mwlang@cybrains.net>

--- a/src/binance/client/rest/endpoints.cr
+++ b/src/binance/client/rest/endpoints.cr
@@ -65,7 +65,9 @@ module Binance::Endpoints
     all_orders:       "v3/allOrders",
     account:          "v3/account",
     my_trades:        "v3/myTrades",
-    user_data_stream: "v1/userDataStream",
+
+    # User Data Stream API Endpoints
+    user_data_stream: "v3/userDataStream",
 
     # Withdraw API Endpoints
     withdraw:         "v3/withdraw.html",
@@ -384,6 +386,10 @@ module Binance::Endpoints
 
   def account
     fetch :get, :signed, :account, AccountResponse
+  end
+
+  def user_data_stream
+    fetch :post, :verified, :user_data_stream, UserDataStreamResponse
   end
 
   # Get trades for a specific account and symbol.

--- a/src/binance/client/rest/responses/user_data_stream_response.cr
+++ b/src/binance/client/rest/responses/user_data_stream_response.cr
@@ -1,0 +1,10 @@
+module Binance::Responses
+  # Typical Server Response:
+  # {
+  #   "listenKey": "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1"
+  # }
+  class UserDataStreamResponse < Responses::ServerResponse
+    @[JSON::Field(key: "listenKey")]
+    getter listen_key : String = ""
+  end
+end

--- a/src/binance/client/rest/responses/user_data_stream_response.cr
+++ b/src/binance/client/rest/responses/user_data_stream_response.cr
@@ -1,8 +1,8 @@
 module Binance::Responses
   # Typical Server Response:
-  # {
-  #   "listenKey": "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1"
-  # }
+  #     {
+  #       "listenKey": "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1"
+  #     }
   class UserDataStreamResponse < Responses::ServerResponse
     @[JSON::Field(key: "listenKey")]
     getter listen_key : String = ""


### PR DESCRIPTION
This small pr just finished implementing the [userDataStream](https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#start-user-data-stream-user_stream) endpoint, after that I'll check if that is enough to make use of the userDataStream websocket data (using `Listener.new`) or if further changes are required.

 I've also updated the README because the urls referencing the binance api have moved to a new repository.

@mwlang There is one thing missing here, I haven't updated the docs because doing it on my end generated less accurate docs (i.e. no hyperlinks to github code snippets, etc... Maybe there are some arguments I'm not giving to `crystal docs`?)